### PR TITLE
Upgrade: adapt-authoring-api to ^3.0.0 and migrate to routes.json

### DIFF
--- a/lib/UserGroupsModule.js
+++ b/lib/UserGroupsModule.js
@@ -6,7 +6,7 @@ import AbstractApiModule from 'adapt-authoring-api'
 class UserGroupsModule extends AbstractApiModule {
   /** @override */
   async setValues () {
-    /** @ignore */ this.root = 'usergroups'
+    await super.setValues()
     /** @ignore */ this.schemaName = 'usergroup'
     /** @ignore */ this.schemaExtensionName = 'usergroups'
     /** @ignore */ this.collectionName = 'usergroups'
@@ -15,8 +15,6 @@ class UserGroupsModule extends AbstractApiModule {
      * @type {Array<AbstractApiModule>}
      */
     this.modules = []
-
-    this.useDefaultRouteConfig()
   }
 
   /** @override */

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "standard": "^17.1.0"
   },
   "dependencies": {
-    "adapt-authoring-api": "^2.0.0"
+    "adapt-authoring-api": "^3.0.0"
   },
   "peerDependencies": {
     "adapt-authoring-core": "^2.0.0",

--- a/routes.json
+++ b/routes.json
@@ -1,0 +1,3 @@
+{
+  "root": "usergroups"
+}

--- a/tests/UserGroupsModule.spec.js
+++ b/tests/UserGroupsModule.spec.js
@@ -46,38 +46,25 @@ describe('UserGroupsModule', () => {
 
 describe('UserGroupsModule.prototype.setValues', () => {
   let instance
-  let useDefaultRouteConfigCalled
 
   beforeEach(() => {
-    useDefaultRouteConfigCalled = false
-
     // Create a minimal instance that mimics the class shape
     // without needing the full AbstractModule constructor chain
     instance = Object.create({
       setValues: null,
-      useDefaultRouteConfig: function () {
-        useDefaultRouteConfigCalled = true
-      },
       log: mock.fn()
     })
 
-    // Import the prototype method
+    // Import the prototype method (without super.setValues — that is tested via routes.json)
     const proto = {
       async setValues () {
-        this.root = 'usergroups'
         this.schemaName = 'usergroup'
         this.schemaExtensionName = 'usergroups'
         this.collectionName = 'usergroups'
         this.modules = []
-        this.useDefaultRouteConfig()
       }
     }
     instance.setValues = proto.setValues.bind(instance)
-  })
-
-  it('should set root to "usergroups"', async () => {
-    await instance.setValues()
-    assert.equal(instance.root, 'usergroups')
   })
 
   it('should set schemaName to "usergroup"', async () => {
@@ -99,11 +86,6 @@ describe('UserGroupsModule.prototype.setValues', () => {
     await instance.setValues()
     assert.deepEqual(instance.modules, [])
     assert.ok(Array.isArray(instance.modules))
-  })
-
-  it('should call useDefaultRouteConfig', async () => {
-    await instance.setValues()
-    assert.equal(useDefaultRouteConfigCalled, true)
   })
 })
 


### PR DESCRIPTION
### Upgrade
* Bump adapt-authoring-api dependency from ^2.0.0 to ^3.0.0

### Update
* Move route definitions from imperative code to routes.json
* Replace useDefaultRouteConfig() with super.setValues() for routes.json loading

### Testing
1. Run `npm test` — all 18 tests pass
2. Verify user group CRUD operations work via the API